### PR TITLE
Text selection and cursors fix

### DIFF
--- a/scrollyeah/scrollyeah.css
+++ b/scrollyeah/scrollyeah.css
@@ -2,6 +2,12 @@
 * https://github.com/artpolikarpov/scrollyeah
 * Copyright (c) 2013 Artem Polikarpov; Licensed MIT */
 .scrollyeah {
+  cursor: default;
+  -webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	-o-user-select: none;
+	user-select: none;
   position: relative;
   overflow: hidden;
   *zoom: 1;


### PR DESCRIPTION
It's bad to allow text selection and use of cursor:text with menu items, because this is not the thing users usually select. You shouldn't distract them with non-default cursors. So,
1) if there are menu items in Scrollyeah and
2) one of them is “current page” (and have no link) and
3) disableIfFit is true,
there will be no cursor:text as well as text selection. It doesn't affect anything in bad way.
